### PR TITLE
Prevent illegal access warnings when running with JDK 11

### DIFF
--- a/README-7.0-patch.md
+++ b/README-7.0-patch.md
@@ -1,1 +1,8 @@
 This - at the moment - is an artifical file to initiate a pull request against 7.0-patch
+
+
+To compile the Finalizer.java source file, use the following commands (JDK 1.7):
+
+`javac -version`: `javac 1.7.0_79`
+
+`javac -source 1.6 -target 1.6 -sourcepath ./src ./src/com/google/common/base/internal/Finalizer.java`

--- a/README-7.0-patch.md
+++ b/README-7.0-patch.md
@@ -1,1 +1,1 @@
-This will contain a short documentation about the 7.0-patch branch.
+This - at the moment - is an artifical file to initiate a pull request against 7.0-patch

--- a/src/com/google/common/base/internal/Finalizer.java
+++ b/src/com/google/common/base/internal/Finalizer.java
@@ -188,17 +188,7 @@ public class Finalizer extends Thread {
   }
 
   public static Field getInheritableThreadLocalsField() {
-    try {
-      Field inheritableThreadLocals
-          = Thread.class.getDeclaredField("inheritableThreadLocals");
-      inheritableThreadLocals.setAccessible(true);
-      return inheritableThreadLocals;
-    } catch (Throwable t) {
-      logger.log(Level.INFO, "Couldn't access Thread.inheritableThreadLocals."
-          + " Reference finalizer threads will inherit thread local"
-          + " values.");
-      return null;
-    }
+    return null;
   }
 
   /** Indicates that it's time to shut down the Finalizer. */


### PR DESCRIPTION
When running with JDK 11, guava 7.0 issues the following illegal access warning:

`Illegal reflective access by com.google.common.base.internal.Finalizer to field java.lang.Thread.inheritableThreadLocals`

This pull request aims to completely prevent this warning. This would allow JDK 17 as runtime without `--add-opens` of `java.lang`.
